### PR TITLE
Adiciona estrutura dos arquivos JSON

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,17 @@
 
 Contribuições sempre serão bem-vindas, sejam pequenas ou grandes. Abaixo, conheça as várias formas de contribuir conosco.
 
-## Issues
+## Tipos de Contribuição
+
+### Resolvendo Issues
 
 As *issues* são um espaço aberto para requisitar criação, mudança ou conserto de material. Também podem ser usadas como um espaço de discussão, mas tenha em mente que o tema sempre deve estar relacionado ao projeto.
+
+### Resolução de Questões
+
+Além de contribuições no desenvolvimento, também é muito importante para o crescimento do projeto que recebamos cada vez mais soluções de questões das provas da POSCOMP. Esse tipo de contribuição é particularmente importante, pois torna o impacto do projeto cada vez mais profundo. 
+
+Se você tem esse tipo de material e quer compartilhar, leia [esse](./docs/QUESTAO.md) e [esse](./docs/AUTOR.md) documentos antes de seguir para a próxima seção.
 
 ## Como Contribuir?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POSCOMP [![Build Status](https://travis-ci.com/OpenDevUFCG/poscomp.svg?branch=master)](https://travis-ci.com/OpenDevUFCG/poscomp) [![chat on Discord](https://img.shields.io/discord/558293573494112257.svg?logo=discord)](https://discordapp.com/invite/vFFGGEE)
 
-Procurando soluções para as questões de provas do POSCOMP de anos anteriores? Chegou ao lugar certo!
+Procurando soluções para as questões de provas da POSCOMP de anos anteriores? Chegou ao lugar certo!
 
 ## Executar Localmente
 

--- a/docs/AUTOR.md
+++ b/docs/AUTOR.md
@@ -1,0 +1,68 @@
+# Compreendendo o JSON dos Autores
+
+Para armazenar os dados dos autores das soluções justificadas de questões da POSCOMP neste repositório são utilizados arquivos `.json`.  Todas as informações são armazenadas em um único arquivo, cuja estrutura está apresentada abaixo.
+
+```json
+{
+    "1": {
+        "nome": ...,
+        "email": ...,
+        "github": ...
+    },
+
+    "2": {
+        "nome": ...,
+        "email": ...,
+        "github": ...
+    }, 
+
+    "3": { 
+        ...
+    },
+    ...
+}
+```
+
+O armazenamento dessas informações visa garantir os créditos de autoria adequados e, em caso de divergências dessa natureza, facilitar o contato com os autores das soluções.
+
+O JSON pode ser encontrado em `poscomp/src/lib/autores/autores.json`.
+
+## Estrutura do JSON
+
+Para garantir que você preencha corretamente o JSON, vamos nos aprofundar um pouco na estrutura utilizada, certo?
+
+### Resumo
+
+| Chave | Descrição | Valor |
+| :--: | :--: | :--: |
+| `nome` | O nome completo do autor de soluções justificadas de questões. | String |
+| `email` | O e-mail para contato do autor de soluções justificadas de questões. | String |
+| `github` | O *username* do autor de soluções justificadas de questões. | String |
+
+### Observações
+
+- O armazenamento do `email` e do `github`são opcionais, no entanto, contribuem bastante para o futuro do projeto.
+
+- Mesmo que um autor contribua com soluções justificadas de várias questões, deve existir apenas um objeto com suas informações no JSON.
+
+- Note que cada objeto com as informações do autor é o valor respectivo a uma chave única. Fique atento para respeitar a sequência pré-existente, pois esses IDs são utilizados para associação entre autores e suas soluções.
+
+- Se essa será sua primeira contribuição, leia também esse [documento](./QUESTAO.md).
+
+### Exemplos
+
+```json
+{
+    "1": {
+        "nome": "Ivyna Rayany Santino Alves",
+        "email": "ivyna.alves@ccc.ufcg.edu.br",
+        "github": "ivynasantino"
+    },
+
+    "2": {
+        "nome": "Matheus Alves dos Santos",
+        "email": "matheus.santos@ccc.ufcg.edu.br",
+        "github": "alvesmatheus"
+    }
+}
+```

--- a/docs/QUESTAO.md
+++ b/docs/QUESTAO.md
@@ -1,0 +1,111 @@
+# Compreendendo os JSONs das Questões
+
+Para armazenar os dados das questões da POSCOMP neste repositório são utilizados arquivos `.json`. Para cada questão, deve existir um arquivo (único) cuja estrutura está apresentada abaixo.
+
+```json
+{
+    "ano": ...,
+    "questao": ...,
+    "area": ...,
+    "enunciado": ...,
+    "img_url": ...,
+    "alternativas": {
+        "A": ..., 
+        "B": ..., 
+        "C": ..., 
+        "D": ..., 
+        "E": ...
+    },
+    "resposta": ...,
+    "autor": ...,
+    "temas": ...,
+    "justificativa": ...
+}
+```
+
+Esse arquivo deve ser nomeado com o número da questão e estar em um diretório nomeado com o ano de realização da prova em que a questão esteve presente. Por sua vez, esse diretório deve estar inserido em ***poscomp/src/lib/***.
+
+Portanto, para a décima questão da prova do POSCOMP de 2016, teríamos `poscomp/src/lib/2016/10.json`. 
+
+## Estrutura do JSON
+
+Para garantir que você preencha corretamente os JSONs, vamos nos aprofundar um pouco na estrutura utilizada, certo?
+
+### Resumo
+
+| Chave | Descrição | Valor |
+| :--: | :--: | :--: |
+| `ano` | O ano de realização da prova em que a questão esteve presente. | String |
+| `questao` | O número da questão (igual ao nome do arquivo `.json`). | String |
+| `area` | A área de conhecimento em que o POSCOMP classificou a questão. | String |
+| `enunciado` | O enunciado completo da questão. | String |
+| `img_url` | Uma lista de URLs das imagens utilizadas no enunciado da questão (se existirem). | Array |
+| `alternativas` | Um objeto que armazena as 5 alternativas de resposta da questão. | Object |
+| `resposta` | O caractere que indica a alternativa correta da questão. | String |
+| `autor` | O nome completo do autor que produziu a justificativa para a resposta. | String |
+| `temas` | Uma lista dos temas que são contemplados pelo conteúdo da questão. | Array |
+| `justificativa` | A justificativa para a escolha da alternativa do gabarito. | String |
+
+### Observações
+
+- Se a questão não utiliza imagens, mantenha o valor de `img_url` como um *array* vazio.
+
+- A `resposta` deve sempre ser uma *string* com um único caractere, preferencialmente em caixa alta.
+
+- Os valores de `img_url` e de `temas` são *arrays* que, quando não-vazios, devem conter exclusivamente *strings*. 
+
+- Todos os textos referentes ao conteúdo das provas (como o `enunciado` e as `alternativas`) devem ser replicados com exatidão.
+
+- O objeto `alternativas` possui 5 propriedades: **A**, **B**, **C**, **D** e **E**. Cada uma delas terá, como valor, a *string* contendo o texto da respectiva alternativa da questão.
+
+- O POSCOMP classifica suas questões entre três áreas: **Matemática**, **Fundamentos da Computação** e **Tecnologia da Computação**. Nenhuma outra área informada será válida.
+
+- Se essa será sua primeira contribuição, leia também o [AUTOR.md](./AUTOR.md).
+
+## Exemplos
+
+Agora você já está pronto para começar a contribuir conosco! Mas antes, que tal dar uma olhada em alguns exemplos?
+
+#### Com Justificativa
+```json
+{
+    "ano": "2015",
+    "questao": "29",
+    "area": "Fundamentos da Computação",
+    "enunciado": "O formato FITS (Flexible Image Transport System) armazena imagens de astronomia. Um cabeçalho FITS é uma coleção de 2.880 bytes contendo registros de 80 bytes ASCII, no qual cada registro contém um metadado. O FITS utiliza o formato ASCII para o cabeçalho e o formato binário para os dados primários. Nesse caso, a inclusão de metadados junto aos dados:",
+    "img_url": [],
+    "alternativas": {
+        "A": "desfavorece a portabilidade, pois dificulta a conversão entre padrões.", 
+        "B": "favorece a portabilidade, embora dificulte a conversão entre padrões.", 
+        "C": "favorece o acesso ao arquivo por terceiros, por possuir conteúdo autoexplicativo.", 
+        "D": "desfavorece o acesso ao arquivo por terceiros.", 
+        "E": "é adequada ao emprego de etiquetas e palavras-chave."
+    },
+    "resposta": "C",
+    "autor": "Matheus Alves dos Santos",
+    "temas": ["Sistemas Operacionais"],
+    "justificativa": "Metadados são um tipo de documentação que descreve os dados em questão [...]."
+}
+```
+
+#### Sem Justificativa
+```json
+{
+    "ano": "2017",
+    "questao": "40",
+    "area": "Fundamentos da Computação",
+    "enunciado": "Assinale a alternativa INCORRETA.",
+    "img_url": [],
+    "alternativas": {
+        "A": "A união de duas linguagens recursivas é uma linguagem recursiva.", 
+        "B": "Segundo a Tese de Church, a capacidade de computação representada pela máquina de Turing é o limite máximo que pode ser atingido por qualquer modelo de computação.", 
+        "C": "Seja L uma linguagem enumerável recursivamente, se o complemento de L for enumerável recursivamente, então L é uma linguagem recursiva.", 
+        "D": "Um problema X é NP-completo quando X pertence à classe NP e, adicionalmente, X é redutível em tempo polinomial para qualquer outro problema Y na classe NP.", 
+        "E": "Todo problema que está na classe P também está na classe NP."
+    },
+    "resposta": "D",
+    "autor": "",
+    "temas": [],
+    "justificativa": ""
+}
+```

--- a/docs/QUESTAO.md
+++ b/docs/QUESTAO.md
@@ -23,9 +23,11 @@ Para armazenar os dados das questões da POSCOMP neste repositório são utiliza
 }
 ```
 
-Esse arquivo deve ser nomeado com o número da questão e estar em um diretório nomeado com o ano de realização da prova em que a questão esteve presente. Por sua vez, esse diretório deve estar inserido em ***poscomp/src/lib/***.
+Esse arquivo deve ser nomeado com o número da questão e estar em um diretório nomeado com o ano de realização da prova em que a questão esteve presente. Por sua vez, esse diretório deve estar inserido em ***poscomp/src/lib/provas/***.
 
-Portanto, para a décima questão da prova do POSCOMP de 2016, teríamos `poscomp/src/lib/2016/10.json`. 
+Portanto, para a décima questão da prova da POSCOMP de 2016, teríamos `poscomp/src/lib/provas/2016/10.json`. 
+
+> **Lembrete:** Ao contribuir com uma solução justificada, as informações do autor da justificativa devem estar presentes no JSON de autores. Se não estão, adicione-as!
 
 ## Estrutura do JSON
 
@@ -37,30 +39,32 @@ Para garantir que você preencha corretamente os JSONs, vamos nos aprofundar um 
 | :--: | :--: | :--: |
 | `ano` | O ano de realização da prova em que a questão esteve presente. | String |
 | `questao` | O número da questão (igual ao nome do arquivo `.json`). | String |
-| `area` | A área de conhecimento em que o POSCOMP classificou a questão. | String |
+| `area` | A área de conhecimento em que a POSCOMP classificou a questão. | String |
 | `enunciado` | O enunciado completo da questão. | String |
 | `img_url` | Uma lista de URLs das imagens utilizadas no enunciado da questão (se existirem). | Array |
 | `alternativas` | Um objeto que armazena as 5 alternativas de resposta da questão. | Object |
 | `resposta` | O caractere que indica a alternativa correta da questão. | String |
-| `autor` | O nome completo do autor que produziu a justificativa para a resposta. | String |
+| `autor` | Uma lista com IDs dos autores que produziram a justificativa para a resposta. | Array |
 | `temas` | Uma lista dos temas que são contemplados pelo conteúdo da questão. | Array |
 | `justificativa` | A justificativa para a escolha da alternativa do gabarito. | String |
 
 ### Observações
 
-- Se a questão não utiliza imagens, mantenha o valor de `img_url` como um *array* vazio.
-
-- A `resposta` deve sempre ser uma *string* com um único caractere, preferencialmente em caixa alta.
-
-- Os valores de `img_url` e de `temas` são *arrays* que, quando não-vazios, devem conter exclusivamente *strings*. 
+- A POSCOMP classifica suas questões entre três áreas: **Matemática**, **Fundamentos da Computação** e **Tecnologia da Computação**. Nenhuma outra área informada será válida.
 
 - Todos os textos referentes ao conteúdo das provas (como o `enunciado` e as `alternativas`) devem ser replicados com exatidão.
 
+- Se a questão não utiliza imagens, mantenha o valor de `img_url` como um *array* vazio.
+
+- Os valores de `img_url`, de `autor` e de `temas` são *arrays* que, quando não-vazios, devem conter exclusivamente *strings*.
+
 - O objeto `alternativas` possui 5 propriedades: **A**, **B**, **C**, **D** e **E**. Cada uma delas terá, como valor, a *string* contendo o texto da respectiva alternativa da questão.
 
-- O POSCOMP classifica suas questões entre três áreas: **Matemática**, **Fundamentos da Computação** e **Tecnologia da Computação**. Nenhuma outra área informada será válida.
+- A `resposta` deve sempre ser uma *string* com um único caractere, preferencialmente em caixa alta.
 
-- Se essa será sua primeira contribuição, leia também o [AUTOR.md](./AUTOR.md).
+- Se a questão ainda não possui justificativa, mantenha os valores de `autor` e `temas` como *arrays* vazios.
+
+- Se essa será sua primeira contribuição, leia também esse [documento](./AUTOR.md).
 
 ## Exemplos
 
@@ -82,9 +86,9 @@ Agora você já está pronto para começar a contribuir conosco! Mas antes, que 
         "E": "é adequada ao emprego de etiquetas e palavras-chave."
     },
     "resposta": "C",
-    "autor": "Matheus Alves dos Santos",
+    "autor": ["1", "2"],
     "temas": ["Sistemas Operacionais"],
-    "justificativa": "Metadados são um tipo de documentação que descreve os dados em questão [...]."
+    "justificativa": "Metadados atuam como uma documentação que descreve os dados em questão [...]."
 }
 ```
 
@@ -104,7 +108,7 @@ Agora você já está pronto para começar a contribuir conosco! Mas antes, que 
         "E": "Todo problema que está na classe P também está na classe NP."
     },
     "resposta": "D",
-    "autor": "",
+    "autor": [],
     "temas": [],
     "justificativa": ""
 }

--- a/lib/2018/1.json
+++ b/lib/2018/1.json
@@ -1,0 +1,18 @@
+{
+    "ano": "2018",
+    "questao": "1",
+    "area": "Matemática",
+    "enunciado": "",
+    "img_url": [],
+    "alternativas": {
+        "A": "", 
+        "B": "", 
+        "C": "", 
+        "D": "", 
+        "E": ""
+    },
+    "resposta": "",
+    "autor": "",
+    "temas": [],
+    "justificativa": ""
+}

--- a/lib/autores/autores.json
+++ b/lib/autores/autores.json
@@ -1,0 +1,7 @@
+{
+    "1": {
+        "nome": "Ivyna Rayany Santino Alves",
+        "email": "ivyna.alves@ccc.ufcg.edu.br",
+        "github": "ivynasantino"
+    }
+}

--- a/lib/provas/2018/1.json
+++ b/lib/provas/2018/1.json
@@ -12,7 +12,7 @@
         "E": ""
     },
     "resposta": "",
-    "autor": "",
+    "autor": [],
     "temas": [],
     "justificativa": ""
 }


### PR DESCRIPTION
Fixes #2 

**Descrição do bug/feature:**
Ausência de estrutura de arquivos JSON para as questões das provas.

**Solução adotada:**
- [X] Criação de um arquivo JSON como exemplo (baseado na descrição de #2).
- [X] Documentação do processo de adição de novas questões.
- [X] Definir e implementar método de armazenamento dos dados dos autores das soluções.
- [X] Documentar processo de adição de novos autores.
- [X] Atualizar `CONTRIBUTING.md`.

**TODO:**
N/A
