### PR TITLE
Adiciona checagem de ponto e virgula

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,5 +22,6 @@
         "react"
     ],
     "rules": {
+      "semi": "error"
     }
 }


### PR DESCRIPTION
**Descrição do bug/feature:** Diferença do uso do ponto e virgula na definição de variaveis e constantes.

**Solução adotada:** Adicionar regra no eslint para sempre ter ponto e virgula.

**TODO:** N/A
<!-- Descreva o que ainda deve ser feito nesse PR ou em PRs futuros. Se não existir um TODO, preencher com N/A-->

<!-- Ao terminar a descrição do PR, apague todos os comentários -->
